### PR TITLE
fix server proto package name

### DIFF
--- a/probes/external/proto/server.proto
+++ b/probes/external/proto/server.proto
@@ -2,7 +2,7 @@
 // probe (in server mode).
 syntax = "proto2";
 
-package cloudprober;
+package cloudprober.probes.external;
 
 // ProbeRequest is the message that cloudprober sends to the external probe
 // server.


### PR DESCRIPTION
This fixes the proto compilation since we require that all proto files within a directory belong to the same proto package