### PR TITLE
Add bazel build files via gazelle

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,0 +1,23 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["cloudprober.go"],
+    importpath = "github.com/yext/cloudprober",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//config:go_default_library",
+        "//config/proto:go_default_library",
+        "//logger:go_default_library",
+        "//metrics:go_default_library",
+        "//probes:go_default_library",
+        "//servers:go_default_library",
+        "//surfacers:go_default_library",
+        "//sysvars:go_default_library",
+        "//targets/lameduck:go_default_library",
+        "//targets/rds/server:go_default_library",
+        "//targets/rtc/rtcreporter:go_default_library",
+        "@com_github_gogo_protobuf//proto:go_default_library",
+        "@com_github_yext_glog//:go_default_library",
+    ],
+)

--- a/cmd/BUILD.bazel
+++ b/cmd/BUILD.bazel
@@ -1,0 +1,23 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["cloudprober.go"],
+    importpath = "github.com/yext/cloudprober/cmd",
+    visibility = ["//visibility:private"],
+    deps = [
+        "//:go_default_library",
+        "//config:go_default_library",
+        "//config/runconfig:go_default_library",
+        "//sysvars:go_default_library",
+        "//web:go_default_library",
+        "@com_github_yext_glog//:go_default_library",
+        "@com_google_cloud_go//compute/metadata:go_default_library",
+    ],
+)
+
+go_binary(
+    name = "cmd",
+    embed = [":go_default_library"],
+    visibility = ["//visibility:public"],
+)

--- a/config/BUILD.bazel
+++ b/config/BUILD.bazel
@@ -1,0 +1,19 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["config.go"],
+    importpath = "github.com/yext/cloudprober/config",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//config/proto:go_default_library",
+        "@com_github_gogo_protobuf//proto:go_default_library",
+        "@com_google_cloud_go//compute/metadata:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["config_test.go"],
+    embed = [":go_default_library"],
+)

--- a/config/proto/BUILD.bazel
+++ b/config/proto/BUILD.bazel
@@ -1,0 +1,39 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
+
+proto_library(
+    name = "cloudprober_proto",
+    srcs = ["config.proto"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//probes/proto:proto_proto",
+        "//servers/proto:proto_proto",
+        "//surfacers/proto:proto_proto",
+        "//targets/proto:proto_proto",
+        "//targets/rds/server/proto:proto_proto",
+        "//targets/rtc/rtcreporter/proto:proto_proto",
+    ],
+)
+
+go_proto_library(
+    name = "cloudprober_go_proto",
+    compilers = ["@io_bazel_rules_go//proto:gogo_proto"],
+    importpath = "github.com/yext/cloudprober/config/proto",
+    proto = ":cloudprober_proto",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//probes/proto:go_default_library",
+        "//servers/proto:go_default_library",
+        "//surfacers/proto:go_default_library",
+        "//targets/proto:go_default_library",
+        "//targets/rds/server/proto:go_default_library",
+        "//targets/rtc/rtcreporter/proto:go_default_library",
+    ],
+)
+
+go_library(
+    name = "go_default_library",
+    embed = [":cloudprober_go_proto"],
+    importpath = "github.com/yext/cloudprober/config/proto",
+    visibility = ["//visibility:public"],
+)

--- a/config/runconfig/BUILD.bazel
+++ b/config/runconfig/BUILD.bazel
@@ -1,0 +1,16 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["runconfig.go"],
+    importpath = "github.com/yext/cloudprober/config/runconfig",
+    visibility = ["//visibility:public"],
+    deps = ["@org_golang_google_grpc//:go_default_library"],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["runconfig_test.go"],
+    embed = [":go_default_library"],
+    deps = ["@org_golang_google_grpc//:go_default_library"],
+)

--- a/examples/extensions/myprober/BUILD.bazel
+++ b/examples/extensions/myprober/BUILD.bazel
@@ -1,0 +1,23 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["myprober.go"],
+    importpath = "github.com/yext/cloudprober/examples/extensions/myprober",
+    visibility = ["//visibility:private"],
+    deps = [
+        "//:go_default_library",
+        "//config:go_default_library",
+        "//examples/extensions/myprober/myprobe:go_default_library",
+        "//probes:go_default_library",
+        "//web:go_default_library",
+        "@com_github_yext_glog//:go_default_library",
+        "@com_google_cloud_go//compute/metadata:go_default_library",
+    ],
+)
+
+go_binary(
+    name = "myprober",
+    embed = [":go_default_library"],
+    visibility = ["//visibility:public"],
+)

--- a/examples/extensions/myprober/myprobe/BUILD.bazel
+++ b/examples/extensions/myprober/myprobe/BUILD.bazel
@@ -1,0 +1,32 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
+
+proto_library(
+    name = "myprober_proto",
+    srcs = ["myprobe.proto"],
+    visibility = ["//visibility:public"],
+    deps = ["//probes/proto:proto_proto"],
+)
+
+go_proto_library(
+    name = "myprober_go_proto",
+    compilers = ["@io_bazel_rules_go//proto:gogo_proto"],
+    importpath = "github.com/yext/cloudprober/examples/extensions/myprober/myprobe",
+    proto = ":myprober_proto",
+    visibility = ["//visibility:public"],
+    deps = ["//probes/proto:go_default_library"],
+)
+
+go_library(
+    name = "go_default_library",
+    srcs = ["myprobe.go"],
+    embed = [":myprober_go_proto"],
+    importpath = "github.com/yext/cloudprober/examples/extensions/myprober/myprobe",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//logger:go_default_library",
+        "//metrics:go_default_library",
+        "//probes/options:go_default_library",
+        "@com_github_hoisie_redis//:go_default_library",
+    ],
+)

--- a/examples/external/BUILD.bazel
+++ b/examples/external/BUILD.bazel
@@ -1,0 +1,20 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["redis_probe.go"],
+    importpath = "github.com/yext/cloudprober/examples/external",
+    visibility = ["//visibility:private"],
+    deps = [
+        "//probes/external/proto:go_default_library",
+        "//probes/external/serverutils:go_default_library",
+        "@com_github_gogo_protobuf//proto:go_default_library",
+        "@com_github_hoisie_redis//:go_default_library",
+    ],
+)
+
+go_binary(
+    name = "external",
+    embed = [":go_default_library"],
+    visibility = ["//visibility:public"],
+)

--- a/logger/BUILD.bazel
+++ b/logger/BUILD.bazel
@@ -1,0 +1,16 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["logger.go"],
+    importpath = "github.com/yext/cloudprober/logger",
+    visibility = ["//visibility:public"],
+    deps = [
+        "@com_github_yext_glog//:go_default_library",
+        "@com_google_cloud_go//compute/metadata:go_default_library",
+        "@com_google_cloud_go//logging:go_default_library",
+        "@go_googleapis//google/api:monitoredres_go_proto",
+        "@org_golang_google_api//option:go_default_library",
+        "@org_golang_x_oauth2//google:go_default_library",
+    ],
+)

--- a/message/BUILD.bazel
+++ b/message/BUILD.bazel
@@ -1,0 +1,22 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["message.go"],
+    importpath = "github.com/yext/cloudprober/message",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//message/proto:go_default_library",
+        "@com_github_gogo_protobuf//proto:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["message_test.go"],
+    embed = [":go_default_library"],
+    deps = [
+        "//message/proto:go_default_library",
+        "@com_github_gogo_protobuf//proto:go_default_library",
+    ],
+)

--- a/message/proto/BUILD.bazel
+++ b/message/proto/BUILD.bazel
@@ -1,0 +1,23 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
+
+proto_library(
+    name = "message_proto",
+    srcs = ["message.proto"],
+    visibility = ["//visibility:public"],
+)
+
+go_proto_library(
+    name = "message_go_proto",
+    compilers = ["@io_bazel_rules_go//proto:gogo_proto"],
+    importpath = "github.com/yext/cloudprober/message/proto",
+    proto = ":message_proto",
+    visibility = ["//visibility:public"],
+)
+
+go_library(
+    name = "go_default_library",
+    embed = [":message_go_proto"],
+    importpath = "github.com/yext/cloudprober/message/proto",
+    visibility = ["//visibility:public"],
+)

--- a/metrics/BUILD.bazel
+++ b/metrics/BUILD.bazel
@@ -1,0 +1,35 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "dist.go",
+        "eventmetrics.go",
+        "float.go",
+        "int.go",
+        "map.go",
+        "metrics.go",
+        "string.go",
+    ],
+    importpath = "github.com/yext/cloudprober/metrics",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//metrics/proto:go_default_library",
+        "@org_golang_google_api//googleapi:go_default_library",
+        "@org_golang_google_api//monitoring/v3:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = [
+        "dist_test.go",
+        "eventmetrics_test.go",
+        "map_test.go",
+    ],
+    embed = [":go_default_library"],
+    deps = [
+        "//metrics/proto:go_default_library",
+        "@com_github_gogo_protobuf//proto:go_default_library",
+    ],
+)

--- a/metrics/proto/BUILD.bazel
+++ b/metrics/proto/BUILD.bazel
@@ -1,0 +1,23 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
+
+proto_library(
+    name = "cloudprober_metrics_proto",
+    srcs = ["dist.proto"],
+    visibility = ["//visibility:public"],
+)
+
+go_proto_library(
+    name = "cloudprober_metrics_go_proto",
+    compilers = ["@io_bazel_rules_go//proto:gogo_proto"],
+    importpath = "github.com/yext/cloudprober/metrics/proto",
+    proto = ":cloudprober_metrics_proto",
+    visibility = ["//visibility:public"],
+)
+
+go_library(
+    name = "go_default_library",
+    embed = [":cloudprober_metrics_go_proto"],
+    importpath = "github.com/yext/cloudprober/metrics/proto",
+    visibility = ["//visibility:public"],
+)

--- a/probes/BUILD.bazel
+++ b/probes/BUILD.bazel
@@ -1,0 +1,43 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "probes.go",
+        "probes_status_tmpl.go",
+    ],
+    importpath = "github.com/yext/cloudprober/probes",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//logger:go_default_library",
+        "//metrics:go_default_library",
+        "//probes/dns:go_default_library",
+        "//probes/external:go_default_library",
+        "//probes/http:go_default_library",
+        "//probes/options:go_default_library",
+        "//probes/ping:go_default_library",
+        "//probes/proto:go_default_library",
+        "//probes/udp:go_default_library",
+        "//probes/udplistener:go_default_library",
+        "//targets/lameduck:go_default_library",
+        "//targets/proto:go_default_library",
+        "//web/formatutils:go_default_library",
+        "@com_github_gogo_protobuf//proto:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["probes_test.go"],
+    embed = [":go_default_library"],
+    deps = [
+        "//logger:go_default_library",
+        "//metrics:go_default_library",
+        "//probes/options:go_default_library",
+        "//probes/probeutils:go_default_library",
+        "//probes/proto:go_default_library",
+        "//probes/testdata:go_default_library",
+        "//targets/proto:go_default_library",
+        "@com_github_gogo_protobuf//proto:go_default_library",
+    ],
+)

--- a/probes/dns/BUILD.bazel
+++ b/probes/dns/BUILD.bazel
@@ -1,0 +1,33 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["dns.go"],
+    importpath = "github.com/yext/cloudprober/probes/dns",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//logger:go_default_library",
+        "//metrics:go_default_library",
+        "//probes/dns/proto:go_default_library",
+        "//probes/options:go_default_library",
+        "//probes/probeutils:go_default_library",
+        "@com_github_miekg_dns//:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["dns_test.go"],
+    embed = [":go_default_library"],
+    deps = [
+        "//logger:go_default_library",
+        "//probes/dns/proto:go_default_library",
+        "//probes/options:go_default_library",
+        "//probes/probeutils:go_default_library",
+        "//targets:go_default_library",
+        "//validators:go_default_library",
+        "//validators/proto:go_default_library",
+        "@com_github_gogo_protobuf//proto:go_default_library",
+        "@com_github_miekg_dns//:go_default_library",
+    ],
+)

--- a/probes/dns/cmd/BUILD.bazel
+++ b/probes/dns/cmd/BUILD.bazel
@@ -1,0 +1,23 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["dns.go"],
+    importpath = "github.com/yext/cloudprober/probes/dns/cmd",
+    visibility = ["//visibility:private"],
+    deps = [
+        "//metrics:go_default_library",
+        "//probes/dns:go_default_library",
+        "//probes/dns/proto:go_default_library",
+        "//probes/options:go_default_library",
+        "//targets:go_default_library",
+        "@com_github_gogo_protobuf//proto:go_default_library",
+        "@com_github_yext_glog//:go_default_library",
+    ],
+)
+
+go_binary(
+    name = "cmd",
+    embed = [":go_default_library"],
+    visibility = ["//visibility:public"],
+)

--- a/probes/dns/proto/BUILD.bazel
+++ b/probes/dns/proto/BUILD.bazel
@@ -1,0 +1,23 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
+
+proto_library(
+    name = "cloudprober_probes_dns_proto",
+    srcs = ["config.proto"],
+    visibility = ["//visibility:public"],
+)
+
+go_proto_library(
+    name = "cloudprober_probes_dns_go_proto",
+    compilers = ["@io_bazel_rules_go//proto:gogo_proto"],
+    importpath = "github.com/yext/cloudprober/probes/dns/proto",
+    proto = ":cloudprober_probes_dns_proto",
+    visibility = ["//visibility:public"],
+)
+
+go_library(
+    name = "go_default_library",
+    embed = [":cloudprober_probes_dns_go_proto"],
+    importpath = "github.com/yext/cloudprober/probes/dns/proto",
+    visibility = ["//visibility:public"],
+)

--- a/probes/external/BUILD.bazel
+++ b/probes/external/BUILD.bazel
@@ -1,0 +1,36 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "external.go",
+        "payload_metrics.go",
+    ],
+    importpath = "github.com/yext/cloudprober/probes/external",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//logger:go_default_library",
+        "//metrics:go_default_library",
+        "//probes/external/proto:go_default_library",
+        "//probes/external/serverutils:go_default_library",
+        "//probes/options:go_default_library",
+        "@com_github_gogo_protobuf//proto:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = [
+        "external_test.go",
+        "payload_metrics_test.go",
+    ],
+    embed = [":go_default_library"],
+    deps = [
+        "//metrics:go_default_library",
+        "//probes/external/proto:go_default_library",
+        "//probes/external/serverutils:go_default_library",
+        "//probes/options:go_default_library",
+        "//targets:go_default_library",
+        "@com_github_gogo_protobuf//proto:go_default_library",
+    ],
+)

--- a/probes/external/cmd/BUILD.bazel
+++ b/probes/external/cmd/BUILD.bazel
@@ -1,0 +1,23 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["external.go"],
+    importpath = "github.com/yext/cloudprober/probes/external/cmd",
+    visibility = ["//visibility:private"],
+    deps = [
+        "//metrics:go_default_library",
+        "//probes/external:go_default_library",
+        "//probes/external/proto:go_default_library",
+        "//probes/options:go_default_library",
+        "//targets:go_default_library",
+        "@com_github_gogo_protobuf//proto:go_default_library",
+        "@com_github_yext_glog//:go_default_library",
+    ],
+)
+
+go_binary(
+    name = "cmd",
+    embed = [":go_default_library"],
+    visibility = ["//visibility:public"],
+)

--- a/probes/external/proto/BUILD.bazel
+++ b/probes/external/proto/BUILD.bazel
@@ -1,0 +1,28 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
+
+proto_library(
+    name = "cloudprober_probes_external_proto",
+    srcs = [
+        "config.proto",
+        "server.proto",
+    ],
+    visibility = ["//visibility:public"],
+    deps = ["//metrics/proto:proto_proto"],
+)
+
+go_proto_library(
+    name = "cloudprober_probes_external_go_proto",
+    compilers = ["@io_bazel_rules_go//proto:gogo_proto"],
+    importpath = "github.com/yext/cloudprober/probes/external/proto",
+    proto = ":cloudprober_probes_external_proto",
+    visibility = ["//visibility:public"],
+    deps = ["//metrics/proto:go_default_library"],
+)
+
+go_library(
+    name = "go_default_library",
+    embed = [":cloudprober_probes_external_go_proto"],
+    importpath = "github.com/yext/cloudprober/probes/external/proto",
+    visibility = ["//visibility:public"],
+)

--- a/probes/external/serverutils/BUILD.bazel
+++ b/probes/external/serverutils/BUILD.bazel
@@ -1,0 +1,12 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["serverutils.go"],
+    importpath = "github.com/yext/cloudprober/probes/external/serverutils",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//probes/external/proto:go_default_library",
+        "@com_github_gogo_protobuf//proto:go_default_library",
+    ],
+)

--- a/probes/http/BUILD.bazel
+++ b/probes/http/BUILD.bazel
@@ -1,0 +1,32 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "http.go",
+        "request.go",
+    ],
+    importpath = "github.com/yext/cloudprober/probes/http",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//logger:go_default_library",
+        "//metrics:go_default_library",
+        "//probes/http/proto:go_default_library",
+        "//probes/options:go_default_library",
+        "//probes/probeutils:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["http_test.go"],
+    embed = [":go_default_library"],
+    deps = [
+        "//metrics:go_default_library",
+        "//probes/http/proto:go_default_library",
+        "//probes/options:go_default_library",
+        "//probes/probeutils:go_default_library",
+        "//targets:go_default_library",
+        "@com_github_gogo_protobuf//proto:go_default_library",
+    ],
+)

--- a/probes/http/cmd/BUILD.bazel
+++ b/probes/http/cmd/BUILD.bazel
@@ -1,0 +1,23 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["http.go"],
+    importpath = "github.com/yext/cloudprober/probes/http/cmd",
+    visibility = ["//visibility:private"],
+    deps = [
+        "//metrics:go_default_library",
+        "//probes/http:go_default_library",
+        "//probes/http/proto:go_default_library",
+        "//probes/options:go_default_library",
+        "//targets:go_default_library",
+        "@com_github_gogo_protobuf//proto:go_default_library",
+        "@com_github_yext_glog//:go_default_library",
+    ],
+)
+
+go_binary(
+    name = "cmd",
+    embed = [":go_default_library"],
+    visibility = ["//visibility:public"],
+)

--- a/probes/http/proto/BUILD.bazel
+++ b/probes/http/proto/BUILD.bazel
@@ -1,0 +1,23 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
+
+proto_library(
+    name = "cloudprober_probes_http_proto",
+    srcs = ["config.proto"],
+    visibility = ["//visibility:public"],
+)
+
+go_proto_library(
+    name = "cloudprober_probes_http_go_proto",
+    compilers = ["@io_bazel_rules_go//proto:gogo_proto"],
+    importpath = "github.com/yext/cloudprober/probes/http/proto",
+    proto = ":cloudprober_probes_http_proto",
+    visibility = ["//visibility:public"],
+)
+
+go_library(
+    name = "go_default_library",
+    embed = [":cloudprober_probes_http_go_proto"],
+    importpath = "github.com/yext/cloudprober/probes/http/proto",
+    visibility = ["//visibility:public"],
+)

--- a/probes/options/BUILD.bazel
+++ b/probes/options/BUILD.bazel
@@ -1,0 +1,18 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["options.go"],
+    importpath = "github.com/yext/cloudprober/probes/options",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//logger:go_default_library",
+        "//metrics:go_default_library",
+        "//probes/probeutils:go_default_library",
+        "//probes/proto:go_default_library",
+        "//targets:go_default_library",
+        "//targets/lameduck:go_default_library",
+        "//targets/proto:go_default_library",
+        "//validators:go_default_library",
+    ],
+)

--- a/probes/ping/BUILD.bazel
+++ b/probes/ping/BUILD.bazel
@@ -1,0 +1,44 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "icmpconn.go",
+        "ping.go",
+        "pingutils.go",
+    ],
+    importpath = "github.com/yext/cloudprober/probes/ping",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//logger:go_default_library",
+        "//metrics:go_default_library",
+        "//probes/options:go_default_library",
+        "//probes/ping/proto:go_default_library",
+        "//probes/probeutils:go_default_library",
+        "//validators:go_default_library",
+        "//validators/integrity:go_default_library",
+        "@org_golang_x_net//icmp:go_default_library",
+        "@org_golang_x_net//ipv4:go_default_library",
+        "@org_golang_x_net//ipv6:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = [
+        "ping_test.go",
+        "pingutils_test.go",
+    ],
+    embed = [":go_default_library"],
+    deps = [
+        "//probes/options:go_default_library",
+        "//probes/ping/proto:go_default_library",
+        "//probes/probeutils:go_default_library",
+        "//targets:go_default_library",
+        "@com_github_gogo_protobuf//proto:go_default_library",
+        "@com_github_yext_glog//:go_default_library",
+        "@org_golang_x_net//icmp:go_default_library",
+        "@org_golang_x_net//ipv4:go_default_library",
+        "@org_golang_x_net//ipv6:go_default_library",
+    ],
+)

--- a/probes/ping/cmd/BUILD.bazel
+++ b/probes/ping/cmd/BUILD.bazel
@@ -1,0 +1,23 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["ping.go"],
+    importpath = "github.com/yext/cloudprober/probes/ping/cmd",
+    visibility = ["//visibility:private"],
+    deps = [
+        "//metrics:go_default_library",
+        "//probes/options:go_default_library",
+        "//probes/ping:go_default_library",
+        "//probes/ping/proto:go_default_library",
+        "//targets:go_default_library",
+        "@com_github_gogo_protobuf//proto:go_default_library",
+        "@com_github_yext_glog//:go_default_library",
+    ],
+)
+
+go_binary(
+    name = "cmd",
+    embed = [":go_default_library"],
+    visibility = ["//visibility:public"],
+)

--- a/probes/ping/proto/BUILD.bazel
+++ b/probes/ping/proto/BUILD.bazel
@@ -1,0 +1,23 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
+
+proto_library(
+    name = "cloudprober_probes_ping_proto",
+    srcs = ["config.proto"],
+    visibility = ["//visibility:public"],
+)
+
+go_proto_library(
+    name = "cloudprober_probes_ping_go_proto",
+    compilers = ["@io_bazel_rules_go//proto:gogo_proto"],
+    importpath = "github.com/yext/cloudprober/probes/ping/proto",
+    proto = ":cloudprober_probes_ping_proto",
+    visibility = ["//visibility:public"],
+)
+
+go_library(
+    name = "go_default_library",
+    embed = [":cloudprober_probes_ping_go_proto"],
+    importpath = "github.com/yext/cloudprober/probes/ping/proto",
+    visibility = ["//visibility:public"],
+)

--- a/probes/probeutils/BUILD.bazel
+++ b/probes/probeutils/BUILD.bazel
@@ -1,0 +1,22 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["probeutils.go"],
+    importpath = "github.com/yext/cloudprober/probes/probeutils",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//logger:go_default_library",
+        "//metrics:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["probeutils_test.go"],
+    embed = [":go_default_library"],
+    deps = [
+        "//logger:go_default_library",
+        "//metrics:go_default_library",
+    ],
+)

--- a/probes/proto/BUILD.bazel
+++ b/probes/proto/BUILD.bazel
@@ -1,0 +1,45 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
+
+proto_library(
+    name = "cloudprober_probes_proto",
+    srcs = ["config.proto"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//metrics/proto:proto_proto",
+        "//probes/dns/proto:proto_proto",
+        "//probes/external/proto:proto_proto",
+        "//probes/http/proto:proto_proto",
+        "//probes/ping/proto:proto_proto",
+        "//probes/udp/proto:proto_proto",
+        "//probes/udplistener/proto:proto_proto",
+        "//targets/proto:proto_proto",
+        "//validators/proto:proto_proto",
+    ],
+)
+
+go_proto_library(
+    name = "cloudprober_probes_go_proto",
+    compilers = ["@io_bazel_rules_go//proto:gogo_proto"],
+    importpath = "github.com/yext/cloudprober/probes/proto",
+    proto = ":cloudprober_probes_proto",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//metrics/proto:go_default_library",
+        "//probes/dns/proto:go_default_library",
+        "//probes/external/proto:go_default_library",
+        "//probes/http/proto:go_default_library",
+        "//probes/ping/proto:go_default_library",
+        "//probes/udp/proto:go_default_library",
+        "//probes/udplistener/proto:go_default_library",
+        "//targets/proto:go_default_library",
+        "//validators/proto:go_default_library",
+    ],
+)
+
+go_library(
+    name = "go_default_library",
+    embed = [":cloudprober_probes_go_proto"],
+    importpath = "github.com/yext/cloudprober/probes/proto",
+    visibility = ["//visibility:public"],
+)

--- a/probes/testdata/BUILD.bazel
+++ b/probes/testdata/BUILD.bazel
@@ -1,0 +1,25 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
+
+proto_library(
+    name = "cloudprober_probes_testdata_proto",
+    srcs = ["testdata.proto"],
+    visibility = ["//visibility:public"],
+    deps = ["//probes/proto:proto_proto"],
+)
+
+go_proto_library(
+    name = "cloudprober_probes_testdata_go_proto",
+    compilers = ["@io_bazel_rules_go//proto:gogo_proto"],
+    importpath = "github.com/yext/cloudprober/probes/testdata",
+    proto = ":cloudprober_probes_testdata_proto",
+    visibility = ["//visibility:public"],
+    deps = ["//probes/proto:go_default_library"],
+)
+
+go_library(
+    name = "go_default_library",
+    embed = [":cloudprober_probes_testdata_go_proto"],
+    importpath = "github.com/yext/cloudprober/probes/testdata",
+    visibility = ["//visibility:public"],
+)

--- a/probes/udp/BUILD.bazel
+++ b/probes/udp/BUILD.bazel
@@ -1,0 +1,32 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["udp.go"],
+    importpath = "github.com/yext/cloudprober/probes/udp",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//logger:go_default_library",
+        "//message:go_default_library",
+        "//metrics:go_default_library",
+        "//probes/options:go_default_library",
+        "//probes/udp/proto:go_default_library",
+        "//servers/udp:go_default_library",
+        "//sysvars:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["udp_test.go"],
+    embed = [":go_default_library"],
+    deps = [
+        "//logger:go_default_library",
+        "//metrics:go_default_library",
+        "//probes/options:go_default_library",
+        "//probes/udp/proto:go_default_library",
+        "//sysvars:go_default_library",
+        "//targets:go_default_library",
+        "@com_github_gogo_protobuf//proto:go_default_library",
+    ],
+)

--- a/probes/udp/cmd/BUILD.bazel
+++ b/probes/udp/cmd/BUILD.bazel
@@ -1,0 +1,23 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["udp.go"],
+    importpath = "github.com/yext/cloudprober/probes/udp/cmd",
+    visibility = ["//visibility:private"],
+    deps = [
+        "//metrics:go_default_library",
+        "//probes/options:go_default_library",
+        "//probes/udp:go_default_library",
+        "//probes/udp/proto:go_default_library",
+        "//targets:go_default_library",
+        "@com_github_gogo_protobuf//proto:go_default_library",
+        "@com_github_yext_glog//:go_default_library",
+    ],
+)
+
+go_binary(
+    name = "cmd",
+    embed = [":go_default_library"],
+    visibility = ["//visibility:public"],
+)

--- a/probes/udp/proto/BUILD.bazel
+++ b/probes/udp/proto/BUILD.bazel
@@ -1,0 +1,23 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
+
+proto_library(
+    name = "cloudprober_probes_udp_proto",
+    srcs = ["config.proto"],
+    visibility = ["//visibility:public"],
+)
+
+go_proto_library(
+    name = "cloudprober_probes_udp_go_proto",
+    compilers = ["@io_bazel_rules_go//proto:gogo_proto"],
+    importpath = "github.com/yext/cloudprober/probes/udp/proto",
+    proto = ":cloudprober_probes_udp_proto",
+    visibility = ["//visibility:public"],
+)
+
+go_library(
+    name = "go_default_library",
+    embed = [":cloudprober_probes_udp_go_proto"],
+    importpath = "github.com/yext/cloudprober/probes/udp/proto",
+    visibility = ["//visibility:public"],
+)

--- a/probes/udplistener/BUILD.bazel
+++ b/probes/udplistener/BUILD.bazel
@@ -1,0 +1,34 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["udplistener.go"],
+    importpath = "github.com/yext/cloudprober/probes/udplistener",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//logger:go_default_library",
+        "//message:go_default_library",
+        "//metrics:go_default_library",
+        "//probes/options:go_default_library",
+        "//probes/probeutils:go_default_library",
+        "//probes/udplistener/proto:go_default_library",
+        "//servers/udp:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["udplistener_test.go"],
+    embed = [":go_default_library"],
+    deps = [
+        "//logger:go_default_library",
+        "//message:go_default_library",
+        "//metrics:go_default_library",
+        "//probes/options:go_default_library",
+        "//probes/probeutils:go_default_library",
+        "//probes/udplistener/proto:go_default_library",
+        "//sysvars:go_default_library",
+        "//targets:go_default_library",
+        "@com_github_gogo_protobuf//proto:go_default_library",
+    ],
+)

--- a/probes/udplistener/proto/BUILD.bazel
+++ b/probes/udplistener/proto/BUILD.bazel
@@ -1,0 +1,23 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
+
+proto_library(
+    name = "cloudprober_probes_udplistener_proto",
+    srcs = ["config.proto"],
+    visibility = ["//visibility:public"],
+)
+
+go_proto_library(
+    name = "cloudprober_probes_udplistener_go_proto",
+    compilers = ["@io_bazel_rules_go//proto:gogo_proto"],
+    importpath = "github.com/yext/cloudprober/probes/udplistener/proto",
+    proto = ":cloudprober_probes_udplistener_proto",
+    visibility = ["//visibility:public"],
+)
+
+go_library(
+    name = "go_default_library",
+    embed = [":cloudprober_probes_udplistener_go_proto"],
+    importpath = "github.com/yext/cloudprober/probes/udplistener/proto",
+    visibility = ["//visibility:public"],
+)

--- a/servers/BUILD.bazel
+++ b/servers/BUILD.bazel
@@ -1,0 +1,17 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["servers.go"],
+    importpath = "github.com/yext/cloudprober/servers",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//logger:go_default_library",
+        "//metrics:go_default_library",
+        "//servers/grpc:go_default_library",
+        "//servers/http:go_default_library",
+        "//servers/proto:go_default_library",
+        "//servers/udp:go_default_library",
+        "//web/formatutils:go_default_library",
+    ],
+)

--- a/servers/grpc/BUILD.bazel
+++ b/servers/grpc/BUILD.bazel
@@ -1,0 +1,33 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["grpc.go"],
+    importpath = "github.com/yext/cloudprober/servers/grpc",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//config/runconfig:go_default_library",
+        "//logger:go_default_library",
+        "//metrics:go_default_library",
+        "//probes/probeutils:go_default_library",
+        "//servers/grpc/proto:go_default_library",
+        "@com_github_gogo_protobuf//proto:go_default_library",
+        "@org_golang_google_grpc//:go_default_library",
+        "@org_golang_google_grpc//health:go_default_library",
+        "@org_golang_google_grpc//health/grpc_health_v1:go_default_library",
+        "@org_golang_google_grpc//reflection:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["grpc_test.go"],
+    embed = [":go_default_library"],
+    deps = [
+        "//config/runconfig:go_default_library",
+        "//logger:go_default_library",
+        "//servers/grpc/proto:go_default_library",
+        "@com_github_gogo_protobuf//proto:go_default_library",
+        "@org_golang_google_grpc//:go_default_library",
+    ],
+)

--- a/servers/grpc/proto/BUILD.bazel
+++ b/servers/grpc/proto/BUILD.bazel
@@ -1,0 +1,26 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
+
+proto_library(
+    name = "cloudprober_servers_grpc_proto",
+    srcs = [
+        "config.proto",
+        "grpcservice.proto",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+go_proto_library(
+    name = "cloudprober_servers_grpc_go_proto",
+    compilers = ["@io_bazel_rules_go//proto:go_grpc"],
+    importpath = "github.com/yext/cloudprober/servers/grpc/proto",
+    proto = ":cloudprober_servers_grpc_proto",
+    visibility = ["//visibility:public"],
+)
+
+go_library(
+    name = "go_default_library",
+    embed = [":cloudprober_servers_grpc_go_proto"],
+    importpath = "github.com/yext/cloudprober/servers/grpc/proto",
+    visibility = ["//visibility:public"],
+)

--- a/servers/http/BUILD.bazel
+++ b/servers/http/BUILD.bazel
@@ -1,0 +1,27 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["http.go"],
+    importpath = "github.com/yext/cloudprober/servers/http",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//logger:go_default_library",
+        "//metrics:go_default_library",
+        "//probes/probeutils:go_default_library",
+        "//servers/http/proto:go_default_library",
+        "//sysvars:go_default_library",
+        "//targets/lameduck:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["http_test.go"],
+    embed = [":go_default_library"],
+    deps = [
+        "//logger:go_default_library",
+        "//metrics:go_default_library",
+        "//targets/lameduck:go_default_library",
+    ],
+)

--- a/servers/http/proto/BUILD.bazel
+++ b/servers/http/proto/BUILD.bazel
@@ -1,0 +1,23 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
+
+proto_library(
+    name = "cloudprober_servers_http_proto",
+    srcs = ["config.proto"],
+    visibility = ["//visibility:public"],
+)
+
+go_proto_library(
+    name = "cloudprober_servers_http_go_proto",
+    compilers = ["@io_bazel_rules_go//proto:gogo_proto"],
+    importpath = "github.com/yext/cloudprober/servers/http/proto",
+    proto = ":cloudprober_servers_http_proto",
+    visibility = ["//visibility:public"],
+)
+
+go_library(
+    name = "go_default_library",
+    embed = [":cloudprober_servers_http_go_proto"],
+    importpath = "github.com/yext/cloudprober/servers/http/proto",
+    visibility = ["//visibility:public"],
+)

--- a/servers/proto/BUILD.bazel
+++ b/servers/proto/BUILD.bazel
@@ -1,0 +1,33 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
+
+proto_library(
+    name = "cloudprober_servers_proto",
+    srcs = ["config.proto"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//servers/grpc/proto:proto_proto",
+        "//servers/http/proto:proto_proto",
+        "//servers/udp/proto:proto_proto",
+    ],
+)
+
+go_proto_library(
+    name = "cloudprober_servers_go_proto",
+    compilers = ["@io_bazel_rules_go//proto:gogo_proto"],
+    importpath = "github.com/yext/cloudprober/servers/proto",
+    proto = ":cloudprober_servers_proto",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//servers/grpc/proto:go_default_library",
+        "//servers/http/proto:go_default_library",
+        "//servers/udp/proto:go_default_library",
+    ],
+)
+
+go_library(
+    name = "go_default_library",
+    embed = [":cloudprober_servers_go_proto"],
+    importpath = "github.com/yext/cloudprober/servers/proto",
+    visibility = ["//visibility:public"],
+)

--- a/servers/udp/BUILD.bazel
+++ b/servers/udp/BUILD.bazel
@@ -1,0 +1,24 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["udp.go"],
+    importpath = "github.com/yext/cloudprober/servers/udp",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//logger:go_default_library",
+        "//metrics:go_default_library",
+        "//servers/udp/proto:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["udp_test.go"],
+    embed = [":go_default_library"],
+    deps = [
+        "//logger:go_default_library",
+        "//servers/udp/proto:go_default_library",
+        "@com_github_gogo_protobuf//proto:go_default_library",
+    ],
+)

--- a/servers/udp/cmd/BUILD.bazel
+++ b/servers/udp/cmd/BUILD.bazel
@@ -1,0 +1,21 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["udp.go"],
+    importpath = "github.com/yext/cloudprober/servers/udp/cmd",
+    visibility = ["//visibility:private"],
+    deps = [
+        "//logger:go_default_library",
+        "//servers/udp:go_default_library",
+        "//servers/udp/proto:go_default_library",
+        "@com_github_gogo_protobuf//proto:go_default_library",
+        "@com_github_yext_glog//:go_default_library",
+    ],
+)
+
+go_binary(
+    name = "cmd",
+    embed = [":go_default_library"],
+    visibility = ["//visibility:public"],
+)

--- a/servers/udp/proto/BUILD.bazel
+++ b/servers/udp/proto/BUILD.bazel
@@ -1,0 +1,23 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
+
+proto_library(
+    name = "cloudprober_servers_udp_proto",
+    srcs = ["config.proto"],
+    visibility = ["//visibility:public"],
+)
+
+go_proto_library(
+    name = "cloudprober_servers_udp_go_proto",
+    compilers = ["@io_bazel_rules_go//proto:gogo_proto"],
+    importpath = "github.com/yext/cloudprober/servers/udp/proto",
+    proto = ":cloudprober_servers_udp_proto",
+    visibility = ["//visibility:public"],
+)
+
+go_library(
+    name = "go_default_library",
+    embed = [":cloudprober_servers_udp_go_proto"],
+    importpath = "github.com/yext/cloudprober/servers/udp/proto",
+    visibility = ["//visibility:public"],
+)

--- a/surfacers/BUILD.bazel
+++ b/surfacers/BUILD.bazel
@@ -1,0 +1,30 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["surfacers.go"],
+    importpath = "github.com/yext/cloudprober/surfacers",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//logger:go_default_library",
+        "//metrics:go_default_library",
+        "//surfacers/file:go_default_library",
+        "//surfacers/postgres:go_default_library",
+        "//surfacers/prometheus:go_default_library",
+        "//surfacers/proto:go_default_library",
+        "//surfacers/stackdriver:go_default_library",
+        "//web/formatutils:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["surfacers_test.go"],
+    embed = [":go_default_library"],
+    deps = [
+        "//surfacers/file:go_default_library",
+        "//surfacers/file/proto:go_default_library",
+        "//surfacers/proto:go_default_library",
+        "@com_github_gogo_protobuf//proto:go_default_library",
+    ],
+)

--- a/surfacers/file/BUILD.bazel
+++ b/surfacers/file/BUILD.bazel
@@ -1,0 +1,26 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["file.go"],
+    importpath = "github.com/yext/cloudprober/surfacers/file",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//logger:go_default_library",
+        "//metrics:go_default_library",
+        "//surfacers/file/proto:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["file_test.go"],
+    embed = [":go_default_library"],
+    deps = [
+        "//logger:go_default_library",
+        "//metrics:go_default_library",
+        "//surfacers/file/proto:go_default_library",
+        "@com_github_gogo_protobuf//proto:go_default_library",
+        "@com_github_kylelemons_godebug//pretty:go_default_library",
+    ],
+)

--- a/surfacers/file/proto/BUILD.bazel
+++ b/surfacers/file/proto/BUILD.bazel
@@ -1,0 +1,23 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
+
+proto_library(
+    name = "cloudprober_surfacer_file_proto",
+    srcs = ["config.proto"],
+    visibility = ["//visibility:public"],
+)
+
+go_proto_library(
+    name = "cloudprober_surfacer_file_go_proto",
+    compilers = ["@io_bazel_rules_go//proto:gogo_proto"],
+    importpath = "github.com/yext/cloudprober/surfacers/file/proto",
+    proto = ":cloudprober_surfacer_file_proto",
+    visibility = ["//visibility:public"],
+)
+
+go_library(
+    name = "go_default_library",
+    embed = [":cloudprober_surfacer_file_go_proto"],
+    importpath = "github.com/yext/cloudprober/surfacers/file/proto",
+    visibility = ["//visibility:public"],
+)

--- a/surfacers/postgres/BUILD.bazel
+++ b/surfacers/postgres/BUILD.bazel
@@ -1,0 +1,21 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["postgres.go"],
+    importpath = "github.com/yext/cloudprober/surfacers/postgres",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//logger:go_default_library",
+        "//metrics:go_default_library",
+        "//surfacers/postgres/proto:go_default_library",
+        "@com_github_lib_pq//:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["postgres_test.go"],
+    embed = [":go_default_library"],
+    deps = ["//metrics:go_default_library"],
+)

--- a/surfacers/postgres/proto/BUILD.bazel
+++ b/surfacers/postgres/proto/BUILD.bazel
@@ -1,0 +1,23 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
+
+proto_library(
+    name = "cloudprober_surfacer_postgres_proto",
+    srcs = ["config.proto"],
+    visibility = ["//visibility:public"],
+)
+
+go_proto_library(
+    name = "cloudprober_surfacer_postgres_go_proto",
+    compilers = ["@io_bazel_rules_go//proto:gogo_proto"],
+    importpath = "github.com/yext/cloudprober/surfacers/postgres/proto",
+    proto = ":cloudprober_surfacer_postgres_proto",
+    visibility = ["//visibility:public"],
+)
+
+go_library(
+    name = "go_default_library",
+    embed = [":cloudprober_surfacer_postgres_go_proto"],
+    importpath = "github.com/yext/cloudprober/surfacers/postgres/proto",
+    visibility = ["//visibility:public"],
+)

--- a/surfacers/prometheus/BUILD.bazel
+++ b/surfacers/prometheus/BUILD.bazel
@@ -1,0 +1,25 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["prometheus.go"],
+    importpath = "github.com/yext/cloudprober/surfacers/prometheus",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//logger:go_default_library",
+        "//metrics:go_default_library",
+        "//surfacers/prometheus/proto:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["prometheus_test.go"],
+    embed = [":go_default_library"],
+    deps = [
+        "//logger:go_default_library",
+        "//metrics:go_default_library",
+        "//surfacers/prometheus/proto:go_default_library",
+        "@com_github_gogo_protobuf//proto:go_default_library",
+    ],
+)

--- a/surfacers/prometheus/proto/BUILD.bazel
+++ b/surfacers/prometheus/proto/BUILD.bazel
@@ -1,0 +1,23 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
+
+proto_library(
+    name = "cloudprober_surfacer_prometheus_proto",
+    srcs = ["config.proto"],
+    visibility = ["//visibility:public"],
+)
+
+go_proto_library(
+    name = "cloudprober_surfacer_prometheus_go_proto",
+    compilers = ["@io_bazel_rules_go//proto:gogo_proto"],
+    importpath = "github.com/yext/cloudprober/surfacers/prometheus/proto",
+    proto = ":cloudprober_surfacer_prometheus_proto",
+    visibility = ["//visibility:public"],
+)
+
+go_library(
+    name = "go_default_library",
+    embed = [":cloudprober_surfacer_prometheus_go_proto"],
+    importpath = "github.com/yext/cloudprober/surfacers/prometheus/proto",
+    visibility = ["//visibility:public"],
+)

--- a/surfacers/proto/BUILD.bazel
+++ b/surfacers/proto/BUILD.bazel
@@ -1,0 +1,35 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
+
+proto_library(
+    name = "cloudprober_surfacer_proto",
+    srcs = ["config.proto"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//surfacers/file/proto:proto_proto",
+        "//surfacers/postgres/proto:proto_proto",
+        "//surfacers/prometheus/proto:proto_proto",
+        "//surfacers/stackdriver/proto:proto_proto",
+    ],
+)
+
+go_proto_library(
+    name = "cloudprober_surfacer_go_proto",
+    compilers = ["@io_bazel_rules_go//proto:gogo_proto"],
+    importpath = "github.com/yext/cloudprober/surfacers/proto",
+    proto = ":cloudprober_surfacer_proto",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//surfacers/file/proto:go_default_library",
+        "//surfacers/postgres/proto:go_default_library",
+        "//surfacers/prometheus/proto:go_default_library",
+        "//surfacers/stackdriver/proto:go_default_library",
+    ],
+)
+
+go_library(
+    name = "go_default_library",
+    embed = [":cloudprober_surfacer_go_proto"],
+    importpath = "github.com/yext/cloudprober/surfacers/proto",
+    visibility = ["//visibility:public"],
+)

--- a/surfacers/stackdriver/BUILD.bazel
+++ b/surfacers/stackdriver/BUILD.bazel
@@ -1,0 +1,28 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["stackdriver.go"],
+    importpath = "github.com/yext/cloudprober/surfacers/stackdriver",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//logger:go_default_library",
+        "//metrics:go_default_library",
+        "//surfacers/stackdriver/proto:go_default_library",
+        "@com_google_cloud_go//compute/metadata:go_default_library",
+        "@org_golang_google_api//monitoring/v3:go_default_library",
+        "@org_golang_x_oauth2//google:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["stackdriver_test.go"],
+    embed = [":go_default_library"],
+    deps = [
+        "//logger:go_default_library",
+        "//metrics:go_default_library",
+        "@com_github_kylelemons_godebug//pretty:go_default_library",
+        "@org_golang_google_api//monitoring/v3:go_default_library",
+    ],
+)

--- a/surfacers/stackdriver/proto/BUILD.bazel
+++ b/surfacers/stackdriver/proto/BUILD.bazel
@@ -1,0 +1,23 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
+
+proto_library(
+    name = "cloudprober_surfacer_stackdriver_proto",
+    srcs = ["config.proto"],
+    visibility = ["//visibility:public"],
+)
+
+go_proto_library(
+    name = "cloudprober_surfacer_stackdriver_go_proto",
+    compilers = ["@io_bazel_rules_go//proto:gogo_proto"],
+    importpath = "github.com/yext/cloudprober/surfacers/stackdriver/proto",
+    proto = ":cloudprober_surfacer_stackdriver_proto",
+    visibility = ["//visibility:public"],
+)
+
+go_library(
+    name = "go_default_library",
+    embed = [":cloudprober_surfacer_stackdriver_go_proto"],
+    importpath = "github.com/yext/cloudprober/surfacers/stackdriver/proto",
+    visibility = ["//visibility:public"],
+)

--- a/sysvars/BUILD.bazel
+++ b/sysvars/BUILD.bazel
@@ -1,0 +1,36 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "runtime.go",
+        "runtime_linux.go",
+        "runtime_nonlinux.go",
+        "sysvars.go",
+        "sysvars_gce.go",
+    ],
+    importpath = "github.com/yext/cloudprober/sysvars",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//config/runconfig:go_default_library",
+        "//logger:go_default_library",
+        "//metrics:go_default_library",
+        "@com_github_yext_glog//:go_default_library",
+        "@com_google_cloud_go//compute/metadata:go_default_library",
+    ] + select({
+        "@io_bazel_rules_go//go/platform:linux": [
+            "@org_golang_x_sys//unix:go_default_library",
+        ],
+        "//conditions:default": [],
+    }),
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["runtime_test.go"],
+    embed = [":go_default_library"],
+    deps = [
+        "//logger:go_default_library",
+        "//metrics:go_default_library",
+    ],
+)

--- a/targets/BUILD.bazel
+++ b/targets/BUILD.bazel
@@ -1,0 +1,31 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["targets.go"],
+    importpath = "github.com/yext/cloudprober/targets",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//logger:go_default_library",
+        "//targets/gce:go_default_library",
+        "//targets/lameduck:go_default_library",
+        "//targets/proto:go_default_library",
+        "//targets/rds/client:go_default_library",
+        "//targets/resolver:go_default_library",
+        "//targets/rtc:go_default_library",
+        "@com_github_gogo_protobuf//proto:go_default_library",
+        "@com_google_cloud_go//compute/metadata:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["targets_test.go"],
+    embed = [":go_default_library"],
+    deps = [
+        "//logger:go_default_library",
+        "//targets/proto:go_default_library",
+        "//targets/testdata:go_default_library",
+        "@com_github_gogo_protobuf//proto:go_default_library",
+    ],
+)

--- a/targets/gce/BUILD.bazel
+++ b/targets/gce/BUILD.bazel
@@ -1,0 +1,32 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "forwarding_rules.go",
+        "gce.go",
+        "gce_utils.go",
+        "instances.go",
+    ],
+    importpath = "github.com/yext/cloudprober/targets/gce",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//logger:go_default_library",
+        "//targets/gce/proto:go_default_library",
+        "//targets/resolver:go_default_library",
+        "@com_google_cloud_go//compute/metadata:go_default_library",
+        "@org_golang_google_api//compute/v1:go_default_library",
+        "@org_golang_x_oauth2//google:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["instances_test.go"],
+    embed = [":go_default_library"],
+    deps = [
+        "//targets/gce/proto:go_default_library",
+        "@com_github_gogo_protobuf//proto:go_default_library",
+        "@org_golang_google_api//compute/v1:go_default_library",
+    ],
+)

--- a/targets/gce/proto/BUILD.bazel
+++ b/targets/gce/proto/BUILD.bazel
@@ -1,0 +1,23 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
+
+proto_library(
+    name = "cloudprober_targets_gce_proto",
+    srcs = ["config.proto"],
+    visibility = ["//visibility:public"],
+)
+
+go_proto_library(
+    name = "cloudprober_targets_gce_go_proto",
+    compilers = ["@io_bazel_rules_go//proto:gogo_proto"],
+    importpath = "github.com/yext/cloudprober/targets/gce/proto",
+    proto = ":cloudprober_targets_gce_proto",
+    visibility = ["//visibility:public"],
+)
+
+go_library(
+    name = "go_default_library",
+    embed = [":cloudprober_targets_gce_go_proto"],
+    importpath = "github.com/yext/cloudprober/targets/gce/proto",
+    visibility = ["//visibility:public"],
+)

--- a/targets/lameduck/BUILD.bazel
+++ b/targets/lameduck/BUILD.bazel
@@ -1,0 +1,25 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["lameduck.go"],
+    importpath = "github.com/yext/cloudprober/targets/lameduck",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//logger:go_default_library",
+        "//targets/lameduck/proto:go_default_library",
+        "//targets/rds/client:go_default_library",
+        "//targets/rds/client/proto:go_default_library",
+        "//targets/rds/proto:go_default_library",
+        "//targets/rtc/rtcservice:go_default_library",
+        "@com_github_gogo_protobuf//proto:go_default_library",
+        "@com_google_cloud_go//compute/metadata:go_default_library",
+        "@org_golang_google_api//runtimeconfig/v1beta1:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["lameduck_test.go"],
+    embed = [":go_default_library"],
+)

--- a/targets/lameduck/proto/BUILD.bazel
+++ b/targets/lameduck/proto/BUILD.bazel
@@ -1,0 +1,23 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
+
+proto_library(
+    name = "cloudprober_targets_lameduck_proto",
+    srcs = ["config.proto"],
+    visibility = ["//visibility:public"],
+)
+
+go_proto_library(
+    name = "cloudprober_targets_lameduck_go_proto",
+    compilers = ["@io_bazel_rules_go//proto:gogo_proto"],
+    importpath = "github.com/yext/cloudprober/targets/lameduck/proto",
+    proto = ":cloudprober_targets_lameduck_proto",
+    visibility = ["//visibility:public"],
+)
+
+go_library(
+    name = "go_default_library",
+    embed = [":cloudprober_targets_lameduck_go_proto"],
+    importpath = "github.com/yext/cloudprober/targets/lameduck/proto",
+    visibility = ["//visibility:public"],
+)

--- a/targets/proto/BUILD.bazel
+++ b/targets/proto/BUILD.bazel
@@ -1,0 +1,35 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
+
+proto_library(
+    name = "cloudprober_targets_proto",
+    srcs = ["targets.proto"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//targets/gce/proto:proto_proto",
+        "//targets/lameduck/proto:proto_proto",
+        "//targets/rds/client/proto:proto_proto",
+        "//targets/rtc/proto:proto_proto",
+    ],
+)
+
+go_proto_library(
+    name = "cloudprober_targets_go_proto",
+    compilers = ["@io_bazel_rules_go//proto:gogo_proto"],
+    importpath = "github.com/yext/cloudprober/targets/proto",
+    proto = ":cloudprober_targets_proto",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//targets/gce/proto:go_default_library",
+        "//targets/lameduck/proto:go_default_library",
+        "//targets/rds/client/proto:go_default_library",
+        "//targets/rtc/proto:go_default_library",
+    ],
+)
+
+go_library(
+    name = "go_default_library",
+    embed = [":cloudprober_targets_go_proto"],
+    importpath = "github.com/yext/cloudprober/targets/proto",
+    visibility = ["//visibility:public"],
+)

--- a/targets/rds/client/BUILD.bazel
+++ b/targets/rds/client/BUILD.bazel
@@ -1,0 +1,28 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["client.go"],
+    importpath = "github.com/yext/cloudprober/targets/rds/client",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//logger:go_default_library",
+        "//targets/rds/client/proto:go_default_library",
+        "//targets/rds/proto:go_default_library",
+        "@org_golang_google_grpc//:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["client_test.go"],
+    embed = [":go_default_library"],
+    deps = [
+        "//logger:go_default_library",
+        "//targets/rds/client/proto:go_default_library",
+        "//targets/rds/proto:go_default_library",
+        "//targets/rds/server:go_default_library",
+        "//targets/rds/server/proto:go_default_library",
+        "@com_github_gogo_protobuf//proto:go_default_library",
+    ],
+)

--- a/targets/rds/client/cmd/BUILD.bazel
+++ b/targets/rds/client/cmd/BUILD.bazel
@@ -1,0 +1,22 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["client.go"],
+    importpath = "github.com/yext/cloudprober/targets/rds/client/cmd",
+    visibility = ["//visibility:private"],
+    deps = [
+        "//logger:go_default_library",
+        "//targets/rds/client:go_default_library",
+        "//targets/rds/client/proto:go_default_library",
+        "//targets/rds/proto:go_default_library",
+        "@com_github_gogo_protobuf//proto:go_default_library",
+        "@com_github_yext_glog//:go_default_library",
+    ],
+)
+
+go_binary(
+    name = "cmd",
+    embed = [":go_default_library"],
+    visibility = ["//visibility:public"],
+)

--- a/targets/rds/client/proto/BUILD.bazel
+++ b/targets/rds/client/proto/BUILD.bazel
@@ -1,0 +1,25 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
+
+proto_library(
+    name = "cloudprober_targets_rds_proto",
+    srcs = ["config.proto"],
+    visibility = ["//visibility:public"],
+    deps = ["//targets/rds/proto:proto_proto"],
+)
+
+go_proto_library(
+    name = "cloudprober_targets_rds_go_proto",
+    compilers = ["@io_bazel_rules_go//proto:gogo_proto"],
+    importpath = "github.com/yext/cloudprober/targets/rds/client/proto",
+    proto = ":cloudprober_targets_rds_proto",
+    visibility = ["//visibility:public"],
+    deps = ["//targets/rds/proto:go_default_library"],
+)
+
+go_library(
+    name = "go_default_library",
+    embed = [":cloudprober_targets_rds_go_proto"],
+    importpath = "github.com/yext/cloudprober/targets/rds/client/proto",
+    visibility = ["//visibility:public"],
+)

--- a/targets/rds/proto/BUILD.bazel
+++ b/targets/rds/proto/BUILD.bazel
@@ -1,0 +1,23 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
+
+proto_library(
+    name = "cloudprober_targets_rds_proto",
+    srcs = ["rds.proto"],
+    visibility = ["//visibility:public"],
+)
+
+go_proto_library(
+    name = "cloudprober_targets_rds_go_proto",
+    compilers = ["@io_bazel_rules_go//proto:go_grpc"],
+    importpath = "github.com/yext/cloudprober/targets/rds/proto",
+    proto = ":cloudprober_targets_rds_proto",
+    visibility = ["//visibility:public"],
+)
+
+go_library(
+    name = "go_default_library",
+    embed = [":cloudprober_targets_rds_go_proto"],
+    importpath = "github.com/yext/cloudprober/targets/rds/proto",
+    visibility = ["//visibility:public"],
+)

--- a/targets/rds/server/BUILD.bazel
+++ b/targets/rds/server/BUILD.bazel
@@ -1,0 +1,26 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["server.go"],
+    importpath = "github.com/yext/cloudprober/targets/rds/server",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//logger:go_default_library",
+        "//metrics:go_default_library",
+        "//targets/rds/proto:go_default_library",
+        "//targets/rds/server/gcp:go_default_library",
+        "//targets/rds/server/proto:go_default_library",
+        "@org_golang_google_grpc//:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["server_test.go"],
+    embed = [":go_default_library"],
+    deps = [
+        "//targets/rds/proto:go_default_library",
+        "@com_github_gogo_protobuf//proto:go_default_library",
+    ],
+)

--- a/targets/rds/server/cmd/BUILD.bazel
+++ b/targets/rds/server/cmd/BUILD.bazel
@@ -1,0 +1,21 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["server.go"],
+    importpath = "github.com/yext/cloudprober/targets/rds/server/cmd",
+    visibility = ["//visibility:private"],
+    deps = [
+        "//logger:go_default_library",
+        "//targets/rds/server:go_default_library",
+        "//targets/rds/server/proto:go_default_library",
+        "@com_github_gogo_protobuf//proto:go_default_library",
+        "@com_github_yext_glog//:go_default_library",
+    ],
+)
+
+go_binary(
+    name = "cmd",
+    embed = [":go_default_library"],
+    visibility = ["//visibility:public"],
+)

--- a/targets/rds/server/filter/BUILD.bazel
+++ b/targets/rds/server/filter/BUILD.bazel
@@ -1,0 +1,9 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["filter.go"],
+    importpath = "github.com/yext/cloudprober/targets/rds/server/filter",
+    visibility = ["//visibility:public"],
+    deps = ["//logger:go_default_library"],
+)

--- a/targets/rds/server/gcp/BUILD.bazel
+++ b/targets/rds/server/gcp/BUILD.bazel
@@ -1,0 +1,39 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "gce_instances.go",
+        "gcp.go",
+        "rtc_variables.go",
+    ],
+    importpath = "github.com/yext/cloudprober/targets/rds/server/gcp",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//logger:go_default_library",
+        "//targets/rds/proto:go_default_library",
+        "//targets/rds/server/filter:go_default_library",
+        "//targets/rds/server/gcp/proto:go_default_library",
+        "@com_github_gogo_protobuf//proto:go_default_library",
+        "@com_google_cloud_go//compute/metadata:go_default_library",
+        "@org_golang_google_api//compute/v1:go_default_library",
+        "@org_golang_google_api//runtimeconfig/v1beta1:go_default_library",
+        "@org_golang_x_oauth2//google:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = [
+        "gce_instances_test.go",
+        "rtc_variables_test.go",
+    ],
+    embed = [":go_default_library"],
+    deps = [
+        "//logger:go_default_library",
+        "//targets/rds/proto:go_default_library",
+        "@com_github_gogo_protobuf//proto:go_default_library",
+        "@org_golang_google_api//compute/v1:go_default_library",
+        "@org_golang_google_api//runtimeconfig/v1beta1:go_default_library",
+    ],
+)

--- a/targets/rds/server/gcp/proto/BUILD.bazel
+++ b/targets/rds/server/gcp/proto/BUILD.bazel
@@ -1,0 +1,23 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
+
+proto_library(
+    name = "cloudprober_targets_rds_gcp_proto",
+    srcs = ["config.proto"],
+    visibility = ["//visibility:public"],
+)
+
+go_proto_library(
+    name = "cloudprober_targets_rds_gcp_go_proto",
+    compilers = ["@io_bazel_rules_go//proto:gogo_proto"],
+    importpath = "github.com/yext/cloudprober/targets/rds/server/gcp/proto",
+    proto = ":cloudprober_targets_rds_gcp_proto",
+    visibility = ["//visibility:public"],
+)
+
+go_library(
+    name = "go_default_library",
+    embed = [":cloudprober_targets_rds_gcp_go_proto"],
+    importpath = "github.com/yext/cloudprober/targets/rds/server/gcp/proto",
+    visibility = ["//visibility:public"],
+)

--- a/targets/rds/server/proto/BUILD.bazel
+++ b/targets/rds/server/proto/BUILD.bazel
@@ -1,0 +1,25 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
+
+proto_library(
+    name = "cloudprober_targets_rds_proto",
+    srcs = ["config.proto"],
+    visibility = ["//visibility:public"],
+    deps = ["//targets/rds/server/gcp/proto:proto_proto"],
+)
+
+go_proto_library(
+    name = "cloudprober_targets_rds_go_proto",
+    compilers = ["@io_bazel_rules_go//proto:gogo_proto"],
+    importpath = "github.com/yext/cloudprober/targets/rds/server/proto",
+    proto = ":cloudprober_targets_rds_proto",
+    visibility = ["//visibility:public"],
+    deps = ["//targets/rds/server/gcp/proto:go_default_library"],
+)
+
+go_library(
+    name = "go_default_library",
+    embed = [":cloudprober_targets_rds_go_proto"],
+    importpath = "github.com/yext/cloudprober/targets/rds/server/proto",
+    visibility = ["//visibility:public"],
+)

--- a/targets/resolver/BUILD.bazel
+++ b/targets/resolver/BUILD.bazel
@@ -1,0 +1,14 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["resolver.go"],
+    importpath = "github.com/yext/cloudprober/targets/resolver",
+    visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["resolver_test.go"],
+    embed = [":go_default_library"],
+)

--- a/targets/rtc/BUILD.bazel
+++ b/targets/rtc/BUILD.bazel
@@ -1,0 +1,29 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["rtc.go"],
+    importpath = "github.com/yext/cloudprober/targets/rtc",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//logger:go_default_library",
+        "//targets/rtc/proto:go_default_library",
+        "//targets/rtc/rtcreporter/proto:go_default_library",
+        "//targets/rtc/rtcservice:go_default_library",
+        "@com_github_gogo_protobuf//proto:go_default_library",
+        "@org_golang_google_api//runtimeconfig/v1beta1:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["rtc_test.go"],
+    embed = [":go_default_library"],
+    deps = [
+        "//logger:go_default_library",
+        "//targets/rtc/rtcreporter/proto:go_default_library",
+        "//targets/rtc/rtcservice:go_default_library",
+        "@com_github_gogo_protobuf//proto:go_default_library",
+        "@com_github_kylelemons_godebug//pretty:go_default_library",
+    ],
+)

--- a/targets/rtc/proto/BUILD.bazel
+++ b/targets/rtc/proto/BUILD.bazel
@@ -1,0 +1,23 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
+
+proto_library(
+    name = "cloudprober_targets_rtc_proto",
+    srcs = ["config.proto"],
+    visibility = ["//visibility:public"],
+)
+
+go_proto_library(
+    name = "cloudprober_targets_rtc_go_proto",
+    compilers = ["@io_bazel_rules_go//proto:gogo_proto"],
+    importpath = "github.com/yext/cloudprober/targets/rtc/proto",
+    proto = ":cloudprober_targets_rtc_proto",
+    visibility = ["//visibility:public"],
+)
+
+go_library(
+    name = "go_default_library",
+    embed = [":cloudprober_targets_rtc_go_proto"],
+    importpath = "github.com/yext/cloudprober/targets/rtc/proto",
+    visibility = ["//visibility:public"],
+)

--- a/targets/rtc/rtcreporter/BUILD.bazel
+++ b/targets/rtc/rtcreporter/BUILD.bazel
@@ -1,0 +1,27 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["rtcreporter.go"],
+    importpath = "github.com/yext/cloudprober/targets/rtc/rtcreporter",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//logger:go_default_library",
+        "//targets/rtc/rtcreporter/proto:go_default_library",
+        "//targets/rtc/rtcservice:go_default_library",
+        "@com_github_gogo_protobuf//proto:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["rtcreporter_test.go"],
+    embed = [":go_default_library"],
+    deps = [
+        "//logger:go_default_library",
+        "//targets/rtc/rtcreporter/proto:go_default_library",
+        "//targets/rtc/rtcservice:go_default_library",
+        "@com_github_gogo_protobuf//proto:go_default_library",
+        "@com_github_kylelemons_godebug//pretty:go_default_library",
+    ],
+)

--- a/targets/rtc/rtcreporter/proto/BUILD.bazel
+++ b/targets/rtc/rtcreporter/proto/BUILD.bazel
@@ -1,0 +1,23 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
+
+proto_library(
+    name = "cloudprober_targets_rtcreporter_proto",
+    srcs = ["rtcreporter.proto"],
+    visibility = ["//visibility:public"],
+)
+
+go_proto_library(
+    name = "cloudprober_targets_rtcreporter_go_proto",
+    compilers = ["@io_bazel_rules_go//proto:gogo_proto"],
+    importpath = "github.com/yext/cloudprober/targets/rtc/rtcreporter/proto",
+    proto = ":cloudprober_targets_rtcreporter_proto",
+    visibility = ["//visibility:public"],
+)
+
+go_library(
+    name = "go_default_library",
+    embed = [":cloudprober_targets_rtcreporter_go_proto"],
+    importpath = "github.com/yext/cloudprober/targets/rtc/rtcreporter/proto",
+    visibility = ["//visibility:public"],
+)

--- a/targets/rtc/rtcservice/BUILD.bazel
+++ b/targets/rtc/rtcservice/BUILD.bazel
@@ -1,0 +1,23 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "rtcservice.go",
+        "rtcservice_stub.go",
+    ],
+    importpath = "github.com/yext/cloudprober/targets/rtc/rtcservice",
+    visibility = ["//visibility:public"],
+    deps = [
+        "@org_golang_google_api//googleapi:go_default_library",
+        "@org_golang_google_api//runtimeconfig/v1beta1:go_default_library",
+        "@org_golang_x_oauth2//google:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["rtcservice_test.go"],
+    embed = [":go_default_library"],
+    deps = ["@com_github_kylelemons_godebug//pretty:go_default_library"],
+)

--- a/targets/testdata/BUILD.bazel
+++ b/targets/testdata/BUILD.bazel
@@ -1,0 +1,25 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
+
+proto_library(
+    name = "cloudprober_targets_testdata_proto",
+    srcs = ["testdata.proto"],
+    visibility = ["//visibility:public"],
+    deps = ["//targets/proto:proto_proto"],
+)
+
+go_proto_library(
+    name = "cloudprober_targets_testdata_go_proto",
+    compilers = ["@io_bazel_rules_go//proto:gogo_proto"],
+    importpath = "github.com/yext/cloudprober/targets/testdata",
+    proto = ":cloudprober_targets_testdata_proto",
+    visibility = ["//visibility:public"],
+    deps = ["//targets/proto:go_default_library"],
+)
+
+go_library(
+    name = "go_default_library",
+    embed = [":cloudprober_targets_testdata_go_proto"],
+    importpath = "github.com/yext/cloudprober/targets/testdata",
+    visibility = ["//visibility:public"],
+)

--- a/validators/BUILD.bazel
+++ b/validators/BUILD.bazel
@@ -1,0 +1,15 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["validators.go"],
+    importpath = "github.com/yext/cloudprober/validators",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//logger:go_default_library",
+        "//validators/http:go_default_library",
+        "//validators/integrity:go_default_library",
+        "//validators/proto:go_default_library",
+        "//validators/regex:go_default_library",
+    ],
+)

--- a/validators/http/BUILD.bazel
+++ b/validators/http/BUILD.bazel
@@ -1,0 +1,23 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["http.go"],
+    importpath = "github.com/yext/cloudprober/validators/http",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//logger:go_default_library",
+        "//validators/http/proto:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["http_test.go"],
+    embed = [":go_default_library"],
+    deps = [
+        "//logger:go_default_library",
+        "//validators/http/proto:go_default_library",
+        "@com_github_gogo_protobuf//proto:go_default_library",
+    ],
+)

--- a/validators/http/proto/BUILD.bazel
+++ b/validators/http/proto/BUILD.bazel
@@ -1,0 +1,23 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
+
+proto_library(
+    name = "cloudprober_validators_http_proto",
+    srcs = ["config.proto"],
+    visibility = ["//visibility:public"],
+)
+
+go_proto_library(
+    name = "cloudprober_validators_http_go_proto",
+    compilers = ["@io_bazel_rules_go//proto:gogo_proto"],
+    importpath = "github.com/yext/cloudprober/validators/http/proto",
+    proto = ":cloudprober_validators_http_proto",
+    visibility = ["//visibility:public"],
+)
+
+go_library(
+    name = "go_default_library",
+    embed = [":cloudprober_validators_http_go_proto"],
+    importpath = "github.com/yext/cloudprober/validators/http/proto",
+    visibility = ["//visibility:public"],
+)

--- a/validators/integrity/BUILD.bazel
+++ b/validators/integrity/BUILD.bazel
@@ -1,0 +1,23 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["integrity.go"],
+    importpath = "github.com/yext/cloudprober/validators/integrity",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//logger:go_default_library",
+        "//probes/probeutils:go_default_library",
+        "//validators/integrity/proto:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["integrity_test.go"],
+    embed = [":go_default_library"],
+    deps = [
+        "//logger:go_default_library",
+        "//validators/integrity/proto:go_default_library",
+    ],
+)

--- a/validators/integrity/proto/BUILD.bazel
+++ b/validators/integrity/proto/BUILD.bazel
@@ -1,0 +1,23 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
+
+proto_library(
+    name = "cloudprober_validators_integrity_proto",
+    srcs = ["config.proto"],
+    visibility = ["//visibility:public"],
+)
+
+go_proto_library(
+    name = "cloudprober_validators_integrity_go_proto",
+    compilers = ["@io_bazel_rules_go//proto:gogo_proto"],
+    importpath = "github.com/yext/cloudprober/validators/integrity/proto",
+    proto = ":cloudprober_validators_integrity_proto",
+    visibility = ["//visibility:public"],
+)
+
+go_library(
+    name = "go_default_library",
+    embed = [":cloudprober_validators_integrity_go_proto"],
+    importpath = "github.com/yext/cloudprober/validators/integrity/proto",
+    visibility = ["//visibility:public"],
+)

--- a/validators/proto/BUILD.bazel
+++ b/validators/proto/BUILD.bazel
@@ -1,0 +1,31 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
+
+proto_library(
+    name = "cloudprober_validators_proto",
+    srcs = ["config.proto"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//validators/http/proto:proto_proto",
+        "//validators/integrity/proto:proto_proto",
+    ],
+)
+
+go_proto_library(
+    name = "cloudprober_validators_go_proto",
+    compilers = ["@io_bazel_rules_go//proto:gogo_proto"],
+    importpath = "github.com/yext/cloudprober/validators/proto",
+    proto = ":cloudprober_validators_proto",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//validators/http/proto:go_default_library",
+        "//validators/integrity/proto:go_default_library",
+    ],
+)
+
+go_library(
+    name = "go_default_library",
+    embed = [":cloudprober_validators_go_proto"],
+    importpath = "github.com/yext/cloudprober/validators/proto",
+    visibility = ["//visibility:public"],
+)

--- a/validators/regex/BUILD.bazel
+++ b/validators/regex/BUILD.bazel
@@ -1,0 +1,16 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["regex.go"],
+    importpath = "github.com/yext/cloudprober/validators/regex",
+    visibility = ["//visibility:public"],
+    deps = ["//logger:go_default_library"],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["regex_test.go"],
+    embed = [":go_default_library"],
+    deps = ["//logger:go_default_library"],
+)

--- a/web/BUILD.bazel
+++ b/web/BUILD.bazel
@@ -1,0 +1,19 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "status_tmpl.go",
+        "web.go",
+    ],
+    importpath = "github.com/yext/cloudprober/web",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//:go_default_library",
+        "//config/runconfig:go_default_library",
+        "//probes:go_default_library",
+        "//servers:go_default_library",
+        "//surfacers:go_default_library",
+        "//sysvars:go_default_library",
+    ],
+)

--- a/web/formatutils/BUILD.bazel
+++ b/web/formatutils/BUILD.bazel
@@ -1,0 +1,9 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["formatutils.go"],
+    importpath = "github.com/yext/cloudprober/web/formatutils",
+    visibility = ["//visibility:public"],
+    deps = ["@com_github_gogo_protobuf//proto:go_default_library"],
+)


### PR DESCRIPTION
gazelle update -go_proto_compiler '@io_bazel_rules_go//proto:gogo_proto' -go_prefix github.com/yext/cloudprober -repo_root `pwd`

Doing this generates mostly correct BUILD files however BUILD files for
the protos end up ignoring the import path/go_prefix so I ran a quick
find and replace to fix this issue.

find . -type f -name "BUILD.bazel" -print0 | xargs -0 sed -i '' -e 's#//github.com/yext/cloudprober/#//#g'