### PR TITLE
Add gazelle directives to work around limitations

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -21,3 +21,39 @@ go_library(
         "@com_github_yext_glog//:go_default_library",
     ],
 )
+
+# gazelle:go_proto_compilers @io_bazel_rules_go//proto:gogo_proto
+# gazelle:go_grpc_compilers @io_bazel_rules_go//proto:gogo_grpc
+# gazelle:prefix github.com/yext/cloudprober
+# gazelle:proto_import_prefix github.com/yext/cloudprober
+# gazelle:proto_strip_import_prefix /
+# gazelle:resolve proto proto github.com/yext/cloudprober/config/proto/config.proto //config/proto:cloudprober_proto
+# gazelle:resolve proto proto github.com/yext/cloudprober/metrics/proto/dist.proto //metrics/proto:cloudprober_metrics_proto
+# gazelle:resolve proto proto github.com/yext/cloudprober/probes/dns/proto/config.proto //probes/dns/proto:cloudprober_probes_dns_proto
+# gazelle:resolve proto proto github.com/yext/cloudprober/probes/external/proto/config.proto //probes/external/proto:cloudprober_probes_external_proto
+# gazelle:resolve proto proto github.com/yext/cloudprober/probes/http/proto/config.proto //probes/http/proto:cloudprober_probes_http_proto
+# gazelle:resolve proto proto github.com/yext/cloudprober/probes/ping/proto/config.proto //probes/ping/proto:cloudprober_probes_ping_proto
+# gazelle:resolve proto proto github.com/yext/cloudprober/probes/proto/config.proto //probes/proto:cloudprober_probes_proto
+# gazelle:resolve proto proto github.com/yext/cloudprober/probes/udp/proto/config.proto //probes/udp/proto:cloudprober_probes_udp_proto
+# gazelle:resolve proto proto github.com/yext/cloudprober/probes/udplistener/proto/config.proto //probes/udplistener/proto:cloudprober_probes_udplistener_proto
+# gazelle:resolve proto proto github.com/yext/cloudprober/servers/grpc/proto/config.proto //servers/grpc/proto:cloudprober_servers_grpc_proto
+# gazelle:resolve proto proto github.com/yext/cloudprober/servers/http/proto/config.proto //servers/http/proto:cloudprober_servers_http_proto
+# gazelle:resolve proto proto github.com/yext/cloudprober/servers/proto/config.proto //servers/proto:cloudprober_servers_proto
+# gazelle:resolve proto proto github.com/yext/cloudprober/servers/udp/proto/config.proto //servers/udp/proto:cloudprober_servers_udp_proto
+# gazelle:resolve proto proto github.com/yext/cloudprober/surfacers/file/proto/config.proto //surfacers/file/proto:cloudprober_surfacer_file_proto
+# gazelle:resolve proto proto github.com/yext/cloudprober/surfacers/postgres/proto/config.proto //surfacers/postgres/proto:cloudprober_surfacer_postgres_proto
+# gazelle:resolve proto proto github.com/yext/cloudprober/surfacers/prometheus/proto/config.proto //surfacers/prometheus/proto:cloudprober_surfacer_prometheus_proto
+# gazelle:resolve proto proto github.com/yext/cloudprober/surfacers/proto/config.proto //surfacers/proto:cloudprober_surfacer_proto
+# gazelle:resolve proto proto github.com/yext/cloudprober/surfacers/stackdriver/proto/config.proto //surfacers/stackdriver/proto:cloudprober_surfacer_stackdriver_proto
+# gazelle:resolve proto proto github.com/yext/cloudprober/targets/gce/proto/config.proto //targets/gce/proto:cloudprober_targets_gce_proto
+# gazelle:resolve proto proto github.com/yext/cloudprober/targets/lameduck/proto/config.proto //targets/lameduck/proto:cloudprober_targets_lameduck_proto
+# gazelle:resolve proto proto github.com/yext/cloudprober/targets/proto/targets.proto //targets/proto:cloudprober_targets_proto
+# gazelle:resolve proto proto github.com/yext/cloudprober/targets/rds/client/proto/config.proto //targets/rds/client/proto:cloudprober_targets_rds_proto
+# gazelle:resolve proto proto github.com/yext/cloudprober/targets/rds/proto/rds.proto //targets/rds/proto:cloudprober_targets_rds_proto
+# gazelle:resolve proto proto github.com/yext/cloudprober/targets/rds/server/gcp/proto/config.proto //targets/rds/server/gcp/proto:cloudprober_targets_rds_gcp_proto
+# gazelle:resolve proto proto github.com/yext/cloudprober/targets/rds/server/proto/config.proto //targets/rds/server/proto:cloudprober_targets_rds_proto
+# gazelle:resolve proto proto github.com/yext/cloudprober/targets/rtc/proto/config.proto //targets/rtc/proto:cloudprober_targets_rtc_proto
+# gazelle:resolve proto proto github.com/yext/cloudprober/targets/rtc/rtcreporter/proto/rtcreporter.proto //targets/rtc/rtcreporter/proto:cloudprober_targets_rtcreporter_proto
+# gazelle:resolve proto proto github.com/yext/cloudprober/validators/http/proto/config.proto //validators/http/proto:cloudprober_validators_http_proto
+# gazelle:resolve proto proto github.com/yext/cloudprober/validators/integrity/proto/config.proto //validators/integrity/proto:cloudprober_validators_integrity_proto
+# gazelle:resolve proto proto github.com/yext/cloudprober/validators/proto/config.proto //validators/proto:cloudprober_validators_proto

--- a/config/proto/BUILD.bazel
+++ b/config/proto/BUILD.bazel
@@ -4,14 +4,16 @@ load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 proto_library(
     name = "cloudprober_proto",
     srcs = ["config.proto"],
+    import_prefix = "github.com/yext/cloudprober",
+    strip_import_prefix = "/",
     visibility = ["//visibility:public"],
     deps = [
-        "//probes/proto:proto_proto",
-        "//servers/proto:proto_proto",
-        "//surfacers/proto:proto_proto",
-        "//targets/proto:proto_proto",
-        "//targets/rds/server/proto:proto_proto",
-        "//targets/rtc/rtcreporter/proto:proto_proto",
+        "//probes/proto:cloudprober_probes_proto",
+        "//servers/proto:cloudprober_servers_proto",
+        "//surfacers/proto:cloudprober_surfacer_proto",
+        "//targets/proto:cloudprober_targets_proto",
+        "//targets/rds/server/proto:cloudprober_targets_rds_proto",
+        "//targets/rtc/rtcreporter/proto:cloudprober_targets_rtcreporter_proto",
     ],
 )
 

--- a/examples/extensions/myprober/myprobe/BUILD.bazel
+++ b/examples/extensions/myprober/myprobe/BUILD.bazel
@@ -4,8 +4,10 @@ load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 proto_library(
     name = "myprober_proto",
     srcs = ["myprobe.proto"],
+    import_prefix = "github.com/yext/cloudprober",
+    strip_import_prefix = "/",
     visibility = ["//visibility:public"],
-    deps = ["//probes/proto:proto_proto"],
+    deps = ["//probes/proto:cloudprober_probes_proto"],
 )
 
 go_proto_library(

--- a/message/proto/BUILD.bazel
+++ b/message/proto/BUILD.bazel
@@ -4,6 +4,8 @@ load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 proto_library(
     name = "message_proto",
     srcs = ["message.proto"],
+    import_prefix = "github.com/yext/cloudprober",
+    strip_import_prefix = "/",
     visibility = ["//visibility:public"],
 )
 

--- a/metrics/proto/BUILD.bazel
+++ b/metrics/proto/BUILD.bazel
@@ -4,6 +4,8 @@ load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 proto_library(
     name = "cloudprober_metrics_proto",
     srcs = ["dist.proto"],
+    import_prefix = "github.com/yext/cloudprober",
+    strip_import_prefix = "/",
     visibility = ["//visibility:public"],
 )
 

--- a/probes/dns/proto/BUILD.bazel
+++ b/probes/dns/proto/BUILD.bazel
@@ -4,6 +4,8 @@ load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 proto_library(
     name = "cloudprober_probes_dns_proto",
     srcs = ["config.proto"],
+    import_prefix = "github.com/yext/cloudprober",
+    strip_import_prefix = "/",
     visibility = ["//visibility:public"],
 )
 

--- a/probes/external/proto/BUILD.bazel
+++ b/probes/external/proto/BUILD.bazel
@@ -7,8 +7,10 @@ proto_library(
         "config.proto",
         "server.proto",
     ],
+    import_prefix = "github.com/yext/cloudprober",
+    strip_import_prefix = "/",
     visibility = ["//visibility:public"],
-    deps = ["//metrics/proto:proto_proto"],
+    deps = ["//metrics/proto:cloudprober_metrics_proto"],
 )
 
 go_proto_library(

--- a/probes/http/proto/BUILD.bazel
+++ b/probes/http/proto/BUILD.bazel
@@ -4,6 +4,8 @@ load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 proto_library(
     name = "cloudprober_probes_http_proto",
     srcs = ["config.proto"],
+    import_prefix = "github.com/yext/cloudprober",
+    strip_import_prefix = "/",
     visibility = ["//visibility:public"],
 )
 

--- a/probes/ping/proto/BUILD.bazel
+++ b/probes/ping/proto/BUILD.bazel
@@ -4,6 +4,8 @@ load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 proto_library(
     name = "cloudprober_probes_ping_proto",
     srcs = ["config.proto"],
+    import_prefix = "github.com/yext/cloudprober",
+    strip_import_prefix = "/",
     visibility = ["//visibility:public"],
 )
 

--- a/probes/proto/BUILD.bazel
+++ b/probes/proto/BUILD.bazel
@@ -4,17 +4,19 @@ load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 proto_library(
     name = "cloudprober_probes_proto",
     srcs = ["config.proto"],
+    import_prefix = "github.com/yext/cloudprober",
+    strip_import_prefix = "/",
     visibility = ["//visibility:public"],
     deps = [
-        "//metrics/proto:proto_proto",
-        "//probes/dns/proto:proto_proto",
-        "//probes/external/proto:proto_proto",
-        "//probes/http/proto:proto_proto",
-        "//probes/ping/proto:proto_proto",
-        "//probes/udp/proto:proto_proto",
-        "//probes/udplistener/proto:proto_proto",
-        "//targets/proto:proto_proto",
-        "//validators/proto:proto_proto",
+        "//metrics/proto:cloudprober_metrics_proto",
+        "//probes/dns/proto:cloudprober_probes_dns_proto",
+        "//probes/external/proto:cloudprober_probes_external_proto",
+        "//probes/http/proto:cloudprober_probes_http_proto",
+        "//probes/ping/proto:cloudprober_probes_ping_proto",
+        "//probes/udp/proto:cloudprober_probes_udp_proto",
+        "//probes/udplistener/proto:cloudprober_probes_udplistener_proto",
+        "//targets/proto:cloudprober_targets_proto",
+        "//validators/proto:cloudprober_validators_proto",
     ],
 )
 

--- a/probes/testdata/BUILD.bazel
+++ b/probes/testdata/BUILD.bazel
@@ -4,8 +4,10 @@ load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 proto_library(
     name = "cloudprober_probes_testdata_proto",
     srcs = ["testdata.proto"],
+    import_prefix = "github.com/yext/cloudprober",
+    strip_import_prefix = "/",
     visibility = ["//visibility:public"],
-    deps = ["//probes/proto:proto_proto"],
+    deps = ["//probes/proto:cloudprober_probes_proto"],
 )
 
 go_proto_library(

--- a/probes/udp/proto/BUILD.bazel
+++ b/probes/udp/proto/BUILD.bazel
@@ -4,6 +4,8 @@ load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 proto_library(
     name = "cloudprober_probes_udp_proto",
     srcs = ["config.proto"],
+    import_prefix = "github.com/yext/cloudprober",
+    strip_import_prefix = "/",
     visibility = ["//visibility:public"],
 )
 

--- a/probes/udplistener/proto/BUILD.bazel
+++ b/probes/udplistener/proto/BUILD.bazel
@@ -4,6 +4,8 @@ load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 proto_library(
     name = "cloudprober_probes_udplistener_proto",
     srcs = ["config.proto"],
+    import_prefix = "github.com/yext/cloudprober",
+    strip_import_prefix = "/",
     visibility = ["//visibility:public"],
 )
 

--- a/servers/grpc/proto/BUILD.bazel
+++ b/servers/grpc/proto/BUILD.bazel
@@ -7,12 +7,14 @@ proto_library(
         "config.proto",
         "grpcservice.proto",
     ],
+    import_prefix = "github.com/yext/cloudprober",
+    strip_import_prefix = "/",
     visibility = ["//visibility:public"],
 )
 
 go_proto_library(
     name = "cloudprober_servers_grpc_go_proto",
-    compilers = ["@io_bazel_rules_go//proto:go_grpc"],
+    compilers = ["@io_bazel_rules_go//proto:gogo_grpc"],
     importpath = "github.com/yext/cloudprober/servers/grpc/proto",
     proto = ":cloudprober_servers_grpc_proto",
     visibility = ["//visibility:public"],

--- a/servers/http/proto/BUILD.bazel
+++ b/servers/http/proto/BUILD.bazel
@@ -4,6 +4,8 @@ load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 proto_library(
     name = "cloudprober_servers_http_proto",
     srcs = ["config.proto"],
+    import_prefix = "github.com/yext/cloudprober",
+    strip_import_prefix = "/",
     visibility = ["//visibility:public"],
 )
 

--- a/servers/proto/BUILD.bazel
+++ b/servers/proto/BUILD.bazel
@@ -4,11 +4,13 @@ load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 proto_library(
     name = "cloudprober_servers_proto",
     srcs = ["config.proto"],
+    import_prefix = "github.com/yext/cloudprober",
+    strip_import_prefix = "/",
     visibility = ["//visibility:public"],
     deps = [
-        "//servers/grpc/proto:proto_proto",
-        "//servers/http/proto:proto_proto",
-        "//servers/udp/proto:proto_proto",
+        "//servers/grpc/proto:cloudprober_servers_grpc_proto",
+        "//servers/http/proto:cloudprober_servers_http_proto",
+        "//servers/udp/proto:cloudprober_servers_udp_proto",
     ],
 )
 

--- a/servers/udp/proto/BUILD.bazel
+++ b/servers/udp/proto/BUILD.bazel
@@ -4,6 +4,8 @@ load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 proto_library(
     name = "cloudprober_servers_udp_proto",
     srcs = ["config.proto"],
+    import_prefix = "github.com/yext/cloudprober",
+    strip_import_prefix = "/",
     visibility = ["//visibility:public"],
 )
 

--- a/surfacers/file/proto/BUILD.bazel
+++ b/surfacers/file/proto/BUILD.bazel
@@ -4,6 +4,8 @@ load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 proto_library(
     name = "cloudprober_surfacer_file_proto",
     srcs = ["config.proto"],
+    import_prefix = "github.com/yext/cloudprober",
+    strip_import_prefix = "/",
     visibility = ["//visibility:public"],
 )
 

--- a/surfacers/postgres/proto/BUILD.bazel
+++ b/surfacers/postgres/proto/BUILD.bazel
@@ -4,6 +4,8 @@ load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 proto_library(
     name = "cloudprober_surfacer_postgres_proto",
     srcs = ["config.proto"],
+    import_prefix = "github.com/yext/cloudprober",
+    strip_import_prefix = "/",
     visibility = ["//visibility:public"],
 )
 

--- a/surfacers/prometheus/proto/BUILD.bazel
+++ b/surfacers/prometheus/proto/BUILD.bazel
@@ -4,6 +4,8 @@ load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 proto_library(
     name = "cloudprober_surfacer_prometheus_proto",
     srcs = ["config.proto"],
+    import_prefix = "github.com/yext/cloudprober",
+    strip_import_prefix = "/",
     visibility = ["//visibility:public"],
 )
 

--- a/surfacers/proto/BUILD.bazel
+++ b/surfacers/proto/BUILD.bazel
@@ -4,12 +4,14 @@ load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 proto_library(
     name = "cloudprober_surfacer_proto",
     srcs = ["config.proto"],
+    import_prefix = "github.com/yext/cloudprober",
+    strip_import_prefix = "/",
     visibility = ["//visibility:public"],
     deps = [
-        "//surfacers/file/proto:proto_proto",
-        "//surfacers/postgres/proto:proto_proto",
-        "//surfacers/prometheus/proto:proto_proto",
-        "//surfacers/stackdriver/proto:proto_proto",
+        "//surfacers/file/proto:cloudprober_surfacer_file_proto",
+        "//surfacers/postgres/proto:cloudprober_surfacer_postgres_proto",
+        "//surfacers/prometheus/proto:cloudprober_surfacer_prometheus_proto",
+        "//surfacers/stackdriver/proto:cloudprober_surfacer_stackdriver_proto",
     ],
 )
 

--- a/surfacers/stackdriver/proto/BUILD.bazel
+++ b/surfacers/stackdriver/proto/BUILD.bazel
@@ -4,6 +4,8 @@ load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 proto_library(
     name = "cloudprober_surfacer_stackdriver_proto",
     srcs = ["config.proto"],
+    import_prefix = "github.com/yext/cloudprober",
+    strip_import_prefix = "/",
     visibility = ["//visibility:public"],
 )
 

--- a/targets/gce/proto/BUILD.bazel
+++ b/targets/gce/proto/BUILD.bazel
@@ -4,6 +4,8 @@ load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 proto_library(
     name = "cloudprober_targets_gce_proto",
     srcs = ["config.proto"],
+    import_prefix = "github.com/yext/cloudprober",
+    strip_import_prefix = "/",
     visibility = ["//visibility:public"],
 )
 

--- a/targets/lameduck/proto/BUILD.bazel
+++ b/targets/lameduck/proto/BUILD.bazel
@@ -4,6 +4,8 @@ load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 proto_library(
     name = "cloudprober_targets_lameduck_proto",
     srcs = ["config.proto"],
+    import_prefix = "github.com/yext/cloudprober",
+    strip_import_prefix = "/",
     visibility = ["//visibility:public"],
 )
 

--- a/targets/proto/BUILD.bazel
+++ b/targets/proto/BUILD.bazel
@@ -4,12 +4,14 @@ load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 proto_library(
     name = "cloudprober_targets_proto",
     srcs = ["targets.proto"],
+    import_prefix = "github.com/yext/cloudprober",
+    strip_import_prefix = "/",
     visibility = ["//visibility:public"],
     deps = [
-        "//targets/gce/proto:proto_proto",
-        "//targets/lameduck/proto:proto_proto",
-        "//targets/rds/client/proto:proto_proto",
-        "//targets/rtc/proto:proto_proto",
+        "//targets/gce/proto:cloudprober_targets_gce_proto",
+        "//targets/lameduck/proto:cloudprober_targets_lameduck_proto",
+        "//targets/rds/client/proto:cloudprober_targets_rds_proto",
+        "//targets/rtc/proto:cloudprober_targets_rtc_proto",
     ],
 )
 

--- a/targets/rds/client/proto/BUILD.bazel
+++ b/targets/rds/client/proto/BUILD.bazel
@@ -4,8 +4,10 @@ load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 proto_library(
     name = "cloudprober_targets_rds_proto",
     srcs = ["config.proto"],
+    import_prefix = "github.com/yext/cloudprober",
+    strip_import_prefix = "/",
     visibility = ["//visibility:public"],
-    deps = ["//targets/rds/proto:proto_proto"],
+    deps = ["//targets/rds/proto:cloudprober_targets_rds_proto"],
 )
 
 go_proto_library(

--- a/targets/rds/proto/BUILD.bazel
+++ b/targets/rds/proto/BUILD.bazel
@@ -4,12 +4,14 @@ load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 proto_library(
     name = "cloudprober_targets_rds_proto",
     srcs = ["rds.proto"],
+    import_prefix = "github.com/yext/cloudprober",
+    strip_import_prefix = "/",
     visibility = ["//visibility:public"],
 )
 
 go_proto_library(
     name = "cloudprober_targets_rds_go_proto",
-    compilers = ["@io_bazel_rules_go//proto:go_grpc"],
+    compilers = ["@io_bazel_rules_go//proto:gogo_grpc"],
     importpath = "github.com/yext/cloudprober/targets/rds/proto",
     proto = ":cloudprober_targets_rds_proto",
     visibility = ["//visibility:public"],

--- a/targets/rds/server/gcp/proto/BUILD.bazel
+++ b/targets/rds/server/gcp/proto/BUILD.bazel
@@ -4,6 +4,8 @@ load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 proto_library(
     name = "cloudprober_targets_rds_gcp_proto",
     srcs = ["config.proto"],
+    import_prefix = "github.com/yext/cloudprober",
+    strip_import_prefix = "/",
     visibility = ["//visibility:public"],
 )
 

--- a/targets/rds/server/proto/BUILD.bazel
+++ b/targets/rds/server/proto/BUILD.bazel
@@ -4,8 +4,10 @@ load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 proto_library(
     name = "cloudprober_targets_rds_proto",
     srcs = ["config.proto"],
+    import_prefix = "github.com/yext/cloudprober",
+    strip_import_prefix = "/",
     visibility = ["//visibility:public"],
-    deps = ["//targets/rds/server/gcp/proto:proto_proto"],
+    deps = ["//targets/rds/server/gcp/proto:cloudprober_targets_rds_gcp_proto"],
 )
 
 go_proto_library(

--- a/targets/rtc/proto/BUILD.bazel
+++ b/targets/rtc/proto/BUILD.bazel
@@ -4,6 +4,8 @@ load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 proto_library(
     name = "cloudprober_targets_rtc_proto",
     srcs = ["config.proto"],
+    import_prefix = "github.com/yext/cloudprober",
+    strip_import_prefix = "/",
     visibility = ["//visibility:public"],
 )
 

--- a/targets/rtc/rtcreporter/proto/BUILD.bazel
+++ b/targets/rtc/rtcreporter/proto/BUILD.bazel
@@ -4,6 +4,8 @@ load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 proto_library(
     name = "cloudprober_targets_rtcreporter_proto",
     srcs = ["rtcreporter.proto"],
+    import_prefix = "github.com/yext/cloudprober",
+    strip_import_prefix = "/",
     visibility = ["//visibility:public"],
 )
 

--- a/targets/testdata/BUILD.bazel
+++ b/targets/testdata/BUILD.bazel
@@ -4,8 +4,10 @@ load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 proto_library(
     name = "cloudprober_targets_testdata_proto",
     srcs = ["testdata.proto"],
+    import_prefix = "github.com/yext/cloudprober",
+    strip_import_prefix = "/",
     visibility = ["//visibility:public"],
-    deps = ["//targets/proto:proto_proto"],
+    deps = ["//targets/proto:cloudprober_targets_proto"],
 )
 
 go_proto_library(

--- a/validators/http/proto/BUILD.bazel
+++ b/validators/http/proto/BUILD.bazel
@@ -4,6 +4,8 @@ load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 proto_library(
     name = "cloudprober_validators_http_proto",
     srcs = ["config.proto"],
+    import_prefix = "github.com/yext/cloudprober",
+    strip_import_prefix = "/",
     visibility = ["//visibility:public"],
 )
 

--- a/validators/integrity/proto/BUILD.bazel
+++ b/validators/integrity/proto/BUILD.bazel
@@ -4,6 +4,8 @@ load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 proto_library(
     name = "cloudprober_validators_integrity_proto",
     srcs = ["config.proto"],
+    import_prefix = "github.com/yext/cloudprober",
+    strip_import_prefix = "/",
     visibility = ["//visibility:public"],
 )
 

--- a/validators/proto/BUILD.bazel
+++ b/validators/proto/BUILD.bazel
@@ -4,10 +4,12 @@ load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 proto_library(
     name = "cloudprober_validators_proto",
     srcs = ["config.proto"],
+    import_prefix = "github.com/yext/cloudprober",
+    strip_import_prefix = "/",
     visibility = ["//visibility:public"],
     deps = [
-        "//validators/http/proto:proto_proto",
-        "//validators/integrity/proto:proto_proto",
+        "//validators/http/proto:cloudprober_validators_http_proto",
+        "//validators/integrity/proto:cloudprober_validators_integrity_proto",
     ],
 )
 


### PR DESCRIPTION
    Add gazelle directives to work around limitations

    import prefix and strip import prefix needed to be set because of:
    https://github.com/bazelbuild/bazel/issues/3867

    resolve directives are to work around bugs/limitations in gazelle and
    were manually crafted from looking at package names in the proto files.

    resolve directives require specifying both a source-lang and import-lang
    despite it being the same because of another bug/limitation within
    gazelle

    Generate protos with:

    gazelle update -repo_root `pwd` && \
    find . -type f -name "BUILD.bazel" -print0 | xargs -0 sed -i '' -e 's#//github.com/yext/cloudprober/#//#g'