### PR TITLE
cloudprober: catch tls handshake errors

### DIFF
--- a/probes/http/http.go
+++ b/probes/http/http.go
@@ -189,6 +189,10 @@ func isClientTimeout(err error) bool {
 //
 // Use for errors returned from http.Client methods (Get, Post).
 func isSSLError(err error) bool {
+	if err == nil {
+		return false
+	}
+
 	if uerr, ok := err.(*url.Error); ok {
 		switch uerr.Err.(type) {
 		case x509.CertificateInvalidError, x509.HostnameError, x509.UnknownAuthorityError:

--- a/probes/http/http.go
+++ b/probes/http/http.go
@@ -193,8 +193,17 @@ func isSSLError(err error) bool {
 		switch uerr.Err.(type) {
 		case x509.CertificateInvalidError, x509.HostnameError, x509.UnknownAuthorityError:
 			return true
+		case tls.RecordHeaderError:
+			return true
 		}
 	}
+
+	// In the case of handshake errors, Go does not have a predefined
+	// typed error. So use prefix matching to catch these errors.
+	if strings.HasPrefix(err.Error(), "tls: ") {
+		return true
+	}
+
 	return false
 }
 


### PR DESCRIPTION
Catch tls handshake errors by adding two more
conditions to the isSSLError. The first is adding
a check to see if there is a record header error.
The next is to check if the error string has a prefix
of "tls: " as this denotes a handshake error in the
go standard library.