### PR TITLE
Cloudprober: use stdout logging always

### DIFF
--- a/cloudprober.go
+++ b/cloudprober.go
@@ -32,7 +32,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/yext/glog"
 	"github.com/gogo/protobuf/proto"
 	"github.com/yext/cloudprober/config"
 	configpb "github.com/yext/cloudprober/config/proto"
@@ -45,6 +44,7 @@ import (
 	"github.com/yext/cloudprober/targets/lameduck"
 	rdsserver "github.com/yext/cloudprober/targets/rds/server"
 	"github.com/yext/cloudprober/targets/rtc/rtcreporter"
+	"github.com/yext/glog"
 )
 
 const (
@@ -122,13 +122,12 @@ func InitFromConfig(configFile string) error {
 	}
 
 	pr := &Prober{}
-	// Initialize sysvars module
-	l, err := logger.NewCloudproberLog(sysvarsModuleName)
-	if err != nil {
-		return err
-	}
+
+	l := logger.NewStdoutCloudproberLog()
+
 	sysvars.Init(l, nil)
 
+	var err error
 	if pr.textConfig, err = config.ParseTemplate(configFile, sysvars.Vars()); err != nil {
 		return err
 	}

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -101,6 +101,14 @@ func NewCloudproberLog(component string) (*Logger, error) {
 	return New(context.Background(), cpPrefix+"."+component)
 }
 
+// NewStdoutCloudproberLog is a constructor for the wrapped Stdout logger.
+// This will not attempt to create a cloud logger in contrast to
+// NewCloudproberLog. This is equivalent to running Cloudprober on a non
+// GCP machine.
+func NewStdoutCloudproberLog() *Logger {
+	return &Logger{}
+}
+
 // New returns a new Logger object with cloud logging client initialized if running on GCE.
 func New(ctx context.Context, logName string) (*Logger, error) {
 	l := &Logger{}


### PR DESCRIPTION
Add a new constructor to only use stdout logging versus trying to create a GCE cloud logger connection.