### PR TITLE
Replace usage of @go_googleapis

### DIFF
--- a/logger/BUILD.bazel
+++ b/logger/BUILD.bazel
@@ -9,7 +9,7 @@ go_library(
         "@com_github_yext_glog//:go_default_library",
         "@com_google_cloud_go_compute_metadata//:go_default_library",
         "@com_google_cloud_go_logging//:go_default_library",
-        "@go_googleapis//google/api:monitoredres_go_proto",
+        "@org_golang_google_genproto_googleapis_api//monitoredres:monitoredres",
         "@org_golang_google_api//option:go_default_library",
         "@org_golang_x_oauth2//google:go_default_library",
     ],


### PR DESCRIPTION
This is needed by rules_go upgrade:
https://github.com/bazelbuild/rules_go/releases/tag/v0.41.0